### PR TITLE
Added support for multiple files

### DIFF
--- a/sample_openapi/uspto.yaml
+++ b/sample_openapi/uspto.yaml
@@ -1,0 +1,210 @@
+openapi: 3.0.1
+servers:
+  - url: '{scheme}://developer.uspto.gov/ds-api'
+    variables:
+      scheme:
+        description: 'The Data Set API is accessible via https and http'
+        enum:
+          - 'https'
+          - 'http'
+        default: 'https'
+info:
+  description: >-
+    The Data Set API (DSAPI) allows the public users to discover and search
+    USPTO exported data sets. This is a generic API that allows USPTO users to
+    make any CSV based data files searchable through API. With the help of GET
+    call, it returns the list of data fields that are searchable. With the help
+    of POST call, data can be fetched based on the filters on the field names.
+    Please note that POST call is used to search the actual data. The reason for
+    the POST call is that it allows users to specify any complex search criteria
+    without worry about the GET size limitations as well as encoding of the
+    input parameters.
+  version: 1.0.0
+  title: USPTO Data Set API
+  contact:
+    name: Open Data Portal
+    url: 'https://developer.uspto.gov'
+    email: developer@uspto.gov
+tags:
+  - name: metadata
+    description: Find out about the data sets
+  - name: search
+    description: Search a data set
+paths:
+  /:
+    get:
+      tags:
+        - metadata
+      operationId: list-data-sets
+      summary: List available data sets
+      responses:
+        '200':
+          description: Returns a list of data sets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dataSetList'
+              example:
+                {
+                  "total": 2,
+                  "apis": [
+                    {
+                      "apiKey": "oa_citations",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+                    },
+                    {
+                      "apiKey": "cancer_moonshot",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+                    }
+                  ]
+                }
+  /{dataset}/{version}/fields:
+    get:
+      tags:
+        - metadata
+      summary: >-
+        Provides the general information about the API and the list of fields
+        that can be used to query the dataset.
+      description: >-
+        This GET API returns the list of all the searchable field names that are
+        in the oa_citations. Please see the 'fields' attribute which returns an
+        array of field names. Each field or a combination of fields can be
+        searched using the syntax options shown below.
+      operationId: list-searchable-fields
+      parameters:
+        - name: dataset
+          in: path
+          description: 'Name of the dataset.'
+          required: true
+          example: "oa_citations"
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          example: "v1"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            The dataset API for the given version is found and it is accessible
+            to consume.
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: >-
+            The combination of dataset name and version is not found in the
+            system or it is not published yet to be consumed by public.
+          content:
+            application/json:
+              schema:
+                type: string
+  /{dataset}/{version}/records:
+    post:
+      tags:
+        - search
+      summary: >-
+        Provides search capability for the data set with the given search
+        criteria.
+      description: >-
+        This API is based on Solr/Lucense Search. The data is indexed using
+        SOLR. This GET API returns the list of all the searchable field names
+        that are in the Solr Index. Please see the 'fields' attribute which
+        returns an array of field names. Each field or a combination of fields
+        can be searched using the Solr/Lucene Syntax. Please refer
+        https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for
+        the query syntax. List of field names that are searchable can be
+        determined using above GET api.
+      operationId: perform-search
+      parameters:
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          schema:
+            type: string
+            default: v1
+        - name: dataset
+          in: path
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          required: true
+          schema:
+            type: string
+            default: oa_citations
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: object
+        '404':
+          description: No matching record found for the given criteria.
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                criteria:
+                  description: >-
+                    Uses Lucene Query Syntax in the format of
+                    propertyName:value, propertyName:[num1 TO num2] and date
+                    range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the
+                    response please see the 'docs' element which has the list of
+                    record objects. Each record structure would consist of all
+                    the fields and their corresponding values.
+                  type: string
+                  default: '*:*'
+                start:
+                  description: Starting record number. Default value is 0.
+                  type: integer
+                  default: 0
+                rows:
+                  description: >-
+                    Specify number of rows to be returned. If you run the search
+                    with default values, in the response you will see 'numFound'
+                    attribute which will tell the number of records available in
+                    the dataset.
+                  type: integer
+                  default: 100
+              required:
+                - criteria
+components:
+  schemas:
+    dataSetList:
+      type: object
+      properties:
+        total:
+          type: integer
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              apiKey:
+                type: string
+                description: To be used as a dataset parameter value
+              apiVersionNumber:
+                type: string
+                description: To be used as a version parameter value
+              apiUrl:
+                type: string
+                format: uriref
+                description: "The URL describing the dataset's fields"
+              apiDocumentationUrl:
+                type: string
+                format: uriref
+                description: A URL to the API console for each API

--- a/src/app/api-path-tree/api-path-tree.component.ts
+++ b/src/app/api-path-tree/api-path-tree.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { getPath, OpenApiSpec, OperationObject, PathItemObject, PathsObject } from '@loopback/openapi-v3-types';
 import { TreeNode } from 'primeng/api';
 import { FileReaderService } from '../services/file-reader.service';
+import { OpenapiTreenodeConverterService } from '../services/openapi-treenode-converter.service';
 
 @Component({
   selector: 'app-api-path-tree',
@@ -11,181 +11,22 @@ import { FileReaderService } from '../services/file-reader.service';
 export class ApiPathTreeComponent implements OnInit {
 
   /**
-   * Array containing the possible HTTP methods which can have operations for a path.
-   */
-  private readonly httpMethods = [
-    'get',
-    'put',
-    'post',
-    'delete',
-    'options',
-    'head',
-    'patch',
-    'trace'
-  ];
-
-  /**
-   * Object holding the OpenAPI specification
-   */
-  private openApiSpec: OpenApiSpec;
-
-  /**
    * Object hoilding the tree nodes to display
    */
   apiPathNodes: TreeNode[] = [];
 
-  constructor(private fileReaderService: FileReaderService) { }
+  constructor(
+    private fileReaderService: FileReaderService,
+    private openApiConverterService: OpenapiTreenodeConverterService ) { }
 
   ngOnInit() {
     this.fileReaderService.apiChanged.subscribe(value => {
-      this.apiSpec = value;
-    });
-  }
-
-  get apiSpec(): OpenApiSpec {
-    return this.openApiSpec;
-  }
-
-  set apiSpec(spec: OpenApiSpec) {
-    this.openApiSpec = spec;
-
-    this.apiPathNodes = [];
-
-    if (this.openApiSpec !== undefined) {
-      /* If there is a specification set, parse out the nodes */
-      const rootNode = this.convertPathsToTree(this.openApiSpec.paths);
-      this.apiPathNodes.push(rootNode);
-    }
-  }
-
-  /**
-   * Create a heirarchy of Tree Nodes based on the supplied path definitions from the OpenAPI specification.
-   * @param paths the paths contained in the API specification.
-   * @returns the root tree node
-   */
-  private convertPathsToTree(paths: PathsObject): TreeNode {
-
-    /* Map of the absolute path to the node definition */
-    const treeNodes = new Map<string, TreeNode>();
-
-    /* Setup the initial root node */
-    const rootNode: TreeNode = {
-      label: '/',
-      leaf: false,
-      children: [],
-      expanded: true
-    };
-    treeNodes.set(rootNode.label, rootNode);
-
-    /* Iterate through each API path key building up the tree nodes */
-    Object.keys(paths).forEach(key => {
-      console.log('Key: %s', key);
-      const apiPath: PathItemObject = getPath(paths, key);
-      console.log(apiPath);
-
-      /* Need to work back up the path structure. Filtering out any blank elements */
-      key.split('/')
-        .filter(value => value.length > 0)
-        .forEach((value, index, pathSegments) => {
-
-          console.log('Loop values: Value %s, Index %d, PathSegments:', value, index);
-          console.log(pathSegments);
-
-
-          /* Work out the path for the node we are trying to work on.
-           * Note that slice does not include the end indexed element, so need to add 1 here.
-           */
-          const pathSoFar = '/'.concat(pathSegments.slice(0, (index + 1)).join('/'));
-          console.log('Path so far: %s', pathSoFar);
-
-          /* Work out the path for the parent */
-          const parentPath = '/'.concat(pathSegments.slice(0, index).join('/'));
-
-          /* Get the parent node. This should always exist as we are working from back to front for the path */
-          const parentNode = treeNodes.get(parentPath);
-          console.log('Parent node: '.concat(parentPath));
-          console.log(parentNode);
-
-          /* Get the node definition if it already exists (for instance we are adding a HTTP method to an existng path definition) */
-          let pathNode = treeNodes.get(pathSoFar);
-          if (pathNode === undefined) {
-
-            /* Did not already exist, create it */
-            console.log('Creating node for path %s', pathSoFar);
-            pathNode = this.createPathNode('/'.concat(value), getPath(paths, pathSoFar));
-            treeNodes.set(pathSoFar, pathNode);
-
-            /* Add it to the parent */
-            parentNode.children.push(pathNode);
-          }
-
-          if (key === pathSoFar) {
-            /* If the path matches the original key then we are at
-             * the level we need to add the HTTP methods */
-            console.log('Path matches the key');
-
-            /* Iterate through the possible http methods, adding nodes as required */
-            this.httpMethods.forEach(method => {
-              if (apiPath[method]) {
-                /* Definition exists for the http method */
-                pathNode.children.push(
-                  this.createHttpMethodNode(method.toUpperCase(), apiPath[method]));
-              }
-            });
-          }
-      });
+      /* Add this specification to our current state */
+      this.openApiConverterService.addApiSpecification(value);
     });
 
-    console.log(rootNode);
-
-    return rootNode;
-
+    this.openApiConverterService.treeNodesChanged.subscribe(value => {
+      this.apiPathNodes = value;
+    });
   }
-
-  /**
-   * Create a non-leaf node for a path.
-   * @param path the path segment to have as the label for the node
-   * @param definition the path section definition
-   */
-  private createPathNode(path: string, definition: PathItemObject): TreeNode {
-
-    const node: TreeNode = {
-      label: path,
-      leaf: false,
-      expanded: true,
-      children: []
-    };
-
-    return node;
-  }
-
-  /**
-   * Create a leaf node for an HTTP Method Operation
-   * @param method the HTTP method
-   * @param operation the details of the Operation
-   */
-  private createHttpMethodNode(method: string, operation: OperationObject): TreeNode {
-
-    const node: OperationTreeNode = {
-      label: method,
-      leaf: true,
-      type: 'operation',
-      styleClass: 'ui-treenode-http-method'
-    };
-
-    /* Add a tooltip */
-    if (operation.description) {
-      node.tooltip = operation.description;
-    } else if (operation.summary) {
-      node.tooltip = operation.summary;
-    }
-
-    return node;
-
-  }
-
-}
-
-export interface OperationTreeNode extends TreeNode {
-  tooltip?: string;
 }

--- a/src/app/file-chooser/file-chooser.component.html
+++ b/src/app/file-chooser/file-chooser.component.html
@@ -3,4 +3,5 @@
 <!-- Cannot use the "accept" attribute as there is not a mime type for YAML -->
 <input type="file"
        id="api-definition-fc" name="api-definition-fc"
+       multiple="multiple"
        (change)="loadFile($event)">

--- a/src/app/file-chooser/file-chooser.component.ts
+++ b/src/app/file-chooser/file-chooser.component.ts
@@ -1,12 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-
-import { OpenApiSpec, PathsObject, getPath, PathItemObject, OperationObject } from '@loopback/openapi-v3-types';
-import { TreeNode } from 'primeng/api';
-
-import * as jsyaml from 'js-yaml';
-import { stringify } from '@angular/core/src/render3/util';
 import { FileReaderService } from '../services/file-reader.service';
+import { OpenapiTreenodeConverterService } from '../services/openapi-treenode-converter.service';
 
 @Component({
   selector: 'app-file-chooser',
@@ -15,24 +9,39 @@ import { FileReaderService } from '../services/file-reader.service';
 })
 export class FileChooserComponent implements OnInit {
 
-  constructor(private fileReaderService: FileReaderService) { }
+  readonly yamlFilenamePattern = /\.yaml/;
+
+  constructor(
+    private fileReaderService: FileReaderService,
+    private openApiConverterService: OpenapiTreenodeConverterService) { }
 
   ngOnInit() {
   }
 
   loadFile(event) {
     console.log(event);
-    const file = event.target.files[0];
 
-    const pattern = /\.yaml/;
+    /* Reset back to having no files loaded */
+    this.openApiConverterService.reset();
 
-    if (!file.name.match(pattern)) {
-      alert('You are trying to upload a non-YAML file. Please choose a YAML file.');
-      return;
-    }
-    console.log(file);
+    /* Process all the selected files.
+     * Note that a FileList isn't an array
+     * so we need to make it one first */
+    const files: FileList = event.target.files;
+    Array.from(files).forEach(file => {
 
-    this.fileReaderService.loadFile(file);
+
+      if (!file.name.match(this.yamlFilenamePattern)) {
+        // TODO: Update message to include offending file
+        alert(`You are trying to upload a non-YAML file (${file.name}). Please choose a YAML file.`);
+        return;
+      }
+      console.log(file);
+
+      this.fileReaderService.loadFile(file);
+    });
+
+
   }
 
 }

--- a/src/app/services/openapi-treenode-converter.service.spec.ts
+++ b/src/app/services/openapi-treenode-converter.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OpenapiTreenodeConverterService } from './openapi-treenode-converter.service';
+
+describe('OpenapiTreenodeConverterService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: OpenapiTreenodeConverterService = TestBed.get(OpenapiTreenodeConverterService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/openapi-treenode-converter.service.ts
+++ b/src/app/services/openapi-treenode-converter.service.ts
@@ -1,0 +1,223 @@
+import { Injectable } from '@angular/core';
+import { TreeNode } from 'primeng/api';
+import { Subject } from 'rxjs';
+import {
+          getPath, OpenApiSpec, OperationObject,
+          PathItemObject, PathsObject
+        } from '@loopback/openapi-v3-types';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * Service which specialises in conversions between OpenAPI Specification
+ * objects and the TreeNode structures used for the visualisation.
+ *
+ * This object will hold state and requires to be "reset" if the
+ * visualisation should throw away items rendered to date.
+ */
+export class OpenapiTreenodeConverterService {
+
+  /**
+   * Array containing the possible HTTP methods which can have operations for a path.
+   */
+  private readonly httpMethods = [
+    'get',
+    'put',
+    'post',
+    'delete',
+    'options',
+    'head',
+    'patch',
+    'trace'
+  ];
+
+  /**
+   * Subject which interested modules can subscribe to
+   * in order to be informed when the nodes for display
+   * change.
+   */
+  readonly treeNodesChanged = new Subject<TreeNode[]>();
+
+  /**
+   * Object hoilding the tree nodes to display
+   */
+  private apiPathNodes: TreeNode[] = [];
+
+  /* Map of the absolute path to the node definition */
+  private treeNodes = new Map<string, TreeNode>();
+
+  constructor() {
+    this.reset();
+  }
+
+  /**
+   * Clear all state and notify that there are no Tree Nodes
+   * for display.
+   */
+  reset() {
+    this.apiPathNodes = [];
+    this.treeNodes = new Map<string, TreeNode>();
+
+    /* Setup the initial root node */
+    const rootNode: TreeNode = {
+      label: '/',
+      leaf: false,
+      children: [],
+      expanded: true
+    };
+    this.treeNodes.set(rootNode.label, rootNode);
+
+
+    /* Notify subscribers that there are no nodes */
+    this.treeNodesChanged.next(this.apiPathNodes);
+  }
+
+  /**
+   * Merge in the paths and operations from the supplied OpenApi Specification
+   * in to the current state in this service and notify subscribers
+   * of the updated Tree Nodes.
+   * @param openApiSpec the specification to merge in.
+   */
+  addApiSpecification(openApiSpec: OpenApiSpec) {
+
+    /* Convert the specification paths into nodes */
+    this.convertPathsToTree(openApiSpec.paths);
+
+
+    if (this.apiPathNodes.length === 0) {
+      /* This must be the first specification being added,
+       * push the root node if it exists.
+       */
+
+
+      const rootNode = this.treeNodes.get('/');
+      if (rootNode) {
+        this.apiPathNodes.push(rootNode);
+      }
+    }
+
+    /* Notify subscribers */
+    this.treeNodesChanged.next(this.apiPathNodes);
+
+  }
+
+  /**
+   * Create a heirarchy of Tree Nodes based on the supplied path definitions from the
+   * OpenAPI specification.
+   *
+   * This will update the internal "treeNodes" map with the nodes which are
+   * created / updated.
+   *
+   * @param paths the paths contained in the API specification.
+   */
+  private convertPathsToTree(paths: PathsObject) {
+
+    /* Iterate through each API path key building up the tree nodes */
+    Object.keys(paths).forEach(key => {
+      console.log('Key: %s', key);
+      const apiPath: PathItemObject = getPath(paths, key);
+      console.log(apiPath);
+
+      /* Need to work back up the path structure. Filtering out any blank elements */
+      key.split('/')
+        .filter(value => value.length > 0)
+        .forEach((value, index, pathSegments) => {
+
+          console.log('Loop values: Value %s, Index %d, PathSegments:', value, index);
+          console.log(pathSegments);
+
+
+          /* Work out the path for the node we are trying to work on.
+           * Note that slice does not include the end indexed element, so need to add 1 here.
+           */
+          const pathSoFar = '/'.concat(pathSegments.slice(0, (index + 1)).join('/'));
+          console.log('Path so far: %s', pathSoFar);
+
+          /* Work out the path for the parent */
+          const parentPath = '/'.concat(pathSegments.slice(0, index).join('/'));
+
+          /* Get the parent node. This should always exist as we are working from back to front for the path */
+          const parentNode = this.treeNodes.get(parentPath);
+          console.log('Parent node: '.concat(parentPath));
+          console.log(parentNode);
+
+          /* Get the node definition if it already exists (for instance we are adding a HTTP method to an existng path definition) */
+          let pathNode = this.treeNodes.get(pathSoFar);
+          if (pathNode === undefined) {
+
+            /* Did not already exist, create it */
+            console.log('Creating node for path %s', pathSoFar);
+            pathNode = this.createPathNode('/'.concat(value), getPath(paths, pathSoFar));
+            this.treeNodes.set(pathSoFar, pathNode);
+
+            /* Add it to the parent */
+            parentNode.children.push(pathNode);
+          }
+
+          if (key === pathSoFar) {
+            /* If the path matches the original key then we are at
+             * the level we need to add the HTTP methods */
+            console.log('Path matches the key');
+
+            /* Iterate through the possible http methods, adding nodes as required */
+            this.httpMethods.forEach(method => {
+              if (apiPath[method]) {
+                /* Definition exists for the http method */
+                pathNode.children.push(
+                  this.createHttpMethodNode(method.toUpperCase(), apiPath[method]));
+              }
+            });
+          }
+      });
+    });
+
+  }
+
+  /**
+   * Create a non-leaf node for a path.
+   * @param path the path segment to have as the label for the node
+   * @param definition the path section definition
+   */
+  private createPathNode(path: string, definition: PathItemObject): TreeNode {
+
+    const node: TreeNode = {
+      label: path,
+      leaf: false,
+      expanded: true,
+      children: []
+    };
+
+    return node;
+  }
+
+  /**
+   * Create a leaf node for an HTTP Method Operation
+   * @param method the HTTP method
+   * @param operation the details of the Operation
+   */
+  private createHttpMethodNode(method: string, operation: OperationObject): TreeNode {
+
+    const node: OperationTreeNode = {
+      label: method,
+      leaf: true,
+      type: 'operation',
+      styleClass: 'ui-treenode-http-method'
+    };
+
+    /* Add a tooltip */
+    if (operation.description) {
+      node.tooltip = operation.description;
+    } else if (operation.summary) {
+      node.tooltip = operation.summary;
+    }
+
+    return node;
+
+  }
+
+}
+
+export interface OperationTreeNode extends TreeNode {
+  tooltip?: string;
+}


### PR DESCRIPTION
Adds support for the file chooser to select multiple files and to combine them into the tree node heirarchy (issue #1).

OpenapiTreenodeConverterService has taken the parsing logic out from the api path tree component and now holds state which is updated for each file selected. It has a "reset" method which is used when a new set of files are loaded to clear previous state.